### PR TITLE
Fix nmcli check order and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Scripts to make using eduroam on linux easier
 
 ## Running the script
 
-You can run the script with: 
-`./add_connection`
+You can run the script with:
+`./add_connection.sh`
 
 There are optional environment variables
 ```

--- a/add_connection.sh
+++ b/add_connection.sh
@@ -4,18 +4,18 @@
 SSID="eduroam"
 CONNECTION_NAME="eduroam"
 
+# Check if nmcli is installed before asking for credentials
+if ! command -v nmcli &> /dev/null; then
+    echo "nmcli could not be found, please install NetworkManager" >&2
+    exit 1
+fi
+
 # Prompt for username
 read -p "Enter your username: " USERNAME
 
 # Prompt for password (input will be hidden)
 read -sp "Enter your password: " PASSWORD
 echo
-
-# Check if nmcli is installed
-if ! command -v nmcli &> /dev/null; then
-    echo "nmcli could not be found, please install NetworkManager"
-    exit 1
-fi
 
 # Get the first Wi-Fi interface
 IFNAME=$(nmcli device status | awk '$2 == "wifi" {print $1; exit}')


### PR DESCRIPTION
## Summary
- avoid asking for credentials when `nmcli` is missing
- update README instructions to use the actual script name

## Testing
- `bash -n add_connection.sh`

------
https://chatgpt.com/codex/tasks/task_e_684877e09370832499fcd175d1a3586b