### PR TITLE
Add Bats test for nmcli powersave

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ There are optional environment variables
 DISABLE_POWERSAVE: Disables power saving on your wifi adapter
 ```
 
+## Running tests
+
+The tests use the [Bats](https://github.com/bats-core/bats-core) framework.
+After installing `bats`, run the test suite with:
+
+```bash
+bats tests
+```
+
 ### TODO:
 
 - [ ] Add support for wpa_supplicant

--- a/tests/add_connection_test.bats
+++ b/tests/add_connection_test.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+  export NMCLI_ARGS_LOG="$BATS_TMPDIR/nmcli_args.log"
+  : > "$NMCLI_ARGS_LOG"
+  rm -f "$BATS_TMPDIR/connection_created"
+  mkdir -p "$BATS_TMPDIR/bin"
+  cat <<'EOS' > "$BATS_TMPDIR/bin/nmcli"
+#!/usr/bin/env bash
+# mock nmcli
+echo "$@" >> "$NMCLI_ARGS_LOG"
+if [[ "$1" == "device" && "$2" == "status" ]]; then
+  echo "wlan0 wifi connected" # minimal output
+  exit 0
+fi
+if [[ "$1" == "connection" && "$2" == "show" ]]; then
+  # first call simulates connection missing; subsequent calls succeed
+  if [[ ! -f "$BATS_TMPDIR/connection_created" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+if [[ "$1" == "connection" && "$2" == "add" ]]; then
+  touch "$BATS_TMPDIR/connection_created"
+  exit 0
+fi
+exit 0
+EOS
+  chmod +x "$BATS_TMPDIR/bin/nmcli"
+  export PATH="$BATS_TMPDIR/bin:$PATH"
+}
+
+@test "DISABLE_POWERSAVE adds powersave argument" {
+  run bash -c 'printf "user\npass\n" | DISABLE_POWERSAVE=1 ./add_connection.sh'
+  grep -q "802-11-wireless.powersave 2" "$NMCLI_ARGS_LOG"
+}
+
+@test "script works without DISABLE_POWERSAVE" {
+  run bash -c 'printf "user\npass\n" | ./add_connection.sh'
+  [ "$status" -eq 0 ]
+  grep -q "connection add" "$NMCLI_ARGS_LOG"
+  ! grep -q "802-11-wireless.powersave 2" "$NMCLI_ARGS_LOG"
+}


### PR DESCRIPTION
## Summary
- add Bats test for `DISABLE_POWERSAVE` option
- mock `nmcli` in test to capture arguments
- ensure script works without the option as well
- document running the test suite with `bats`

## Testing
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_6848787bbb6c8324834bba6d08b1a1b7