### PR TITLE
Fix comment wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@ Scripts to make using eduroam on linux easier
 
 ## Running the script
 
-You can run the script with: 
-`./add_connection`
+You can run the script with:
+`./add_connection [--no-up]`
 
 There are optional environment variables
 ```
 DISABLE_POWERSAVE: Disables power saving on your wifi adapter
+```
+
+Script arguments
+```
+--no-up: Skip activating the connection after it is created
 ```
 
 ### TODO:

--- a/add_connection.sh
+++ b/add_connection.sh
@@ -4,6 +4,16 @@
 SSID="eduroam"
 CONNECTION_NAME="eduroam"
 
+# Optional arguments
+SKIP_UP=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-up)
+            SKIP_UP=true
+            ;;
+    esac
+done
+
 # Prompt for username
 read -p "Enter your username: " USERNAME
 
@@ -39,8 +49,10 @@ nmcli connection add type wifi \
     802-1x.phase2-auth mschapv2 \
     802-1x.password "$PASSWORD"
 
-# Optionally, bring the connection up
-nmcli connection up "$CONNECTION_NAME"
+# Bring the connection up
+if [ "$SKIP_UP" != true ]; then
+    nmcli connection up "$CONNECTION_NAME"
+fi
 
 # Verify the connection
 if nmcli connection show "$CONNECTION_NAME" &> /dev/null; then


### PR DESCRIPTION
## Summary
- update optional wording to definitive statement
- add `--no-up` argument to skip bringing the connection up
- document the new option

## Testing
- `bash -n add_connection.sh`


------
https://chatgpt.com/codex/tasks/task_e_6848787638a8832493c350f05122a36e